### PR TITLE
Update gemtoabox.rb

### DIFF
--- a/lib/gemtoabox.rb
+++ b/lib/gemtoabox.rb
@@ -1,5 +1,6 @@
 require "gemtoabox/version"
 require 'fileutils'
+require 'tmpdir'
 
 module Gemtoabox
 


### PR DESCRIPTION
without 
require 'tmpdir'

gemtoabox-0.1.2/lib/gemtoabox.rb:9:in `initialize': undefined method `mktmpdir' for Dir:Class (NoMethodError)